### PR TITLE
fix: preserve DTM ingestion across severity policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,8 @@ ______________________________________________________________________
   | Medium | Medium |
   | Low | Low |
 
+  The connector matches these values to enabled Splunk SOAR severity names. If a stock name is not enabled, High maps to the highest-ranked enabled severity, Medium maps to the enabled default (or the middle-ranked severity if no default is identified), and Low maps to the lowest-ranked enabled severity. Missing and unrecognized DTM severity values map to the highest-ranked enabled severity.
+
 - **Container Creation:**\
   Each DTM alert will result in the creation of a separate container. One artifact will be created inside the container and will have certain important fields from alert visible inside the artifact. To get complete details about the alert, download the artifact JSON.
 

--- a/actions/google_threat_intelligence_on_poll.py
+++ b/actions/google_threat_intelligence_on_poll.py
@@ -459,6 +459,13 @@ class OnPoll(BaseAction):
             self._connector.debug_print("No data found in response")
             return phantom.APP_SUCCESS, None
 
+        severity_mapping = self._get_dtm_severity_mapping()
+        if not severity_mapping:
+            return self._action_result.set_status(
+                phantom.APP_ERROR,
+                "Unable to resolve the enabled Splunk SOAR severity configuration",
+            ), None
+
         latest_alert_time = data[0].get("created_at")
         checkpoint_alert_time = None
         for alert in reversed(data):
@@ -466,7 +473,8 @@ class OnPoll(BaseAction):
             alert_time = alert.get("created_at")
             alert_title = alert.get("title")
             alert_description = alert.get("alert_summary")
-            alert_severity = consts.DTM_SEVERITY_MAPPING.get(str(alert.get("severity", "")).lower(), "high")
+            provider_severity = str(alert.get("severity") or "").strip().lower()
+            alert_severity = severity_mapping.get(provider_severity, severity_mapping["high"])
             alert_status = alert.get("status")
             container_status = consts.DTM_STATUS_MAPPING.get(alert_status, "new")
             container_data = {
@@ -512,6 +520,39 @@ class OnPoll(BaseAction):
         if checkpoint_alert_time != latest_alert_time:
             return self._action_result.set_status(phantom.APP_ERROR, "Failed to ingest all DTM alerts; preserved checkpoint for retry"), None
         return phantom.APP_SUCCESS, None
+
+    def _get_dtm_severity_mapping(self):
+        """Map provider severity levels onto the deployment's enabled severities."""
+        try:
+            url = f"{self._connector.get_phantom_base_url()}rest/severity?page_size=100&sort=order&order=asc"
+            response = requests.get(url, verify=ph_config.platform_strict_tls, timeout=30)
+            if response.status_code != 200:
+                self._connector.debug_print(f"Failed to query severities: HTTP {response.status_code}")
+                return None
+
+            configured_severities = [
+                severity for severity in response.json().get("data", []) if severity.get("name") and not severity.get("disabled", False)
+            ]
+        except Exception as e:
+            self._connector.debug_print(f"Error querying severities: {e!s}")
+            return None
+
+        if not configured_severities:
+            self._connector.debug_print("The deployment has no enabled severities")
+            return None
+
+        configured_severities.sort(key=lambda severity: severity.get("order", 0))
+        names_by_level = {str(severity["name"]).strip().lower(): severity["name"] for severity in configured_severities}
+        highest = configured_severities[0]["name"]
+        lowest = configured_severities[-1]["name"]
+        default = next((severity["name"] for severity in configured_severities if severity.get("is_default")), None)
+        middle = configured_severities[len(configured_severities) // 2]["name"]
+
+        return {
+            "high": names_by_level.get("high", highest),
+            "medium": names_by_level.get("medium", default or middle),
+            "low": names_by_level.get("low", lowest),
+        }
 
     def handle_polling_rs_events(self):
         """Handle polling for RS alerts using OAuth and the Google Threat Intelligence Alerts API.
@@ -902,6 +943,7 @@ class OnPoll(BaseAction):
             "Alert Type": alert.get("alert_type"),
             "Alert Title": alert.get("title"),
             "Alert Summary": alert.get("alert_summary"),
+            "Alert Severity": alert.get("severity"),
             "Alert Status": alert.get("status"),
             "AI Doc Summary": alert.get("ai_doc_summary"),
             "Aggregated Under ID": alert.get("aggregated_under_id"),

--- a/actions/google_threat_intelligence_on_poll.py
+++ b/actions/google_threat_intelligence_on_poll.py
@@ -468,6 +468,7 @@ class OnPoll(BaseAction):
 
         latest_alert_time = data[0].get("created_at")
         checkpoint_alert_time = None
+        ingest_failed = False
         for alert in reversed(data):
             alert_id = alert.get("id")
             alert_time = alert.get("created_at")
@@ -487,10 +488,13 @@ class OnPoll(BaseAction):
             ret_val, message, container_id = self._connector.save_container(container_data)
             if phantom.is_fail(ret_val):
                 self._connector.debug_print(f"Failed to create container: {message}")
-                break
+                ingest_failed = True
+                continue
             if message and message == "Duplicate container found":
-                self._connector.debug_print(f"Container already exists, skipping ingestion for alert: {alert_id}")
-                checkpoint_alert_time = alert_time
+                self._connector.debug_print(f"Container already exists; verifying artifact ingestion for alert: {alert_id}")
+            if not container_id:
+                self._connector.debug_print(f"No container ID returned for alert: {alert_id}")
+                ingest_failed = True
                 continue
             dtm_cef = self.__get_cef_dtm(alert)
             artifact_data = {
@@ -507,9 +511,11 @@ class OnPoll(BaseAction):
 
             if phantom.is_fail(ret_val):
                 self._connector.debug_print(f"Failed to create artifact: {message}")
-                break
-            checkpoint_alert_time = alert_time
-        else:
+                ingest_failed = True
+                continue
+            if not ingest_failed:
+                checkpoint_alert_time = alert_time
+        if not ingest_failed:
             checkpoint_alert_time = latest_alert_time
 
         if not self._is_poll_now and checkpoint_alert_time:
@@ -517,8 +523,11 @@ class OnPoll(BaseAction):
             self._state["last_alert_time"] = checkpoint_alert_time
             self._connector.state = self._state
             self._connector.save_state(self._state)
-        if checkpoint_alert_time != latest_alert_time:
-            return self._action_result.set_status(phantom.APP_ERROR, "Failed to ingest all DTM alerts; preserved checkpoint for retry"), None
+        if ingest_failed:
+            return self._action_result.set_status(
+                phantom.APP_ERROR,
+                "Failed to ingest one or more DTM alerts; preserved checkpoint for retry",
+            ), None
         return phantom.APP_SUCCESS, None
 
     def _get_dtm_severity_mapping(self):

--- a/google_threat_intelligence_consts.py
+++ b/google_threat_intelligence_consts.py
@@ -118,7 +118,6 @@ PASS_ERROR_CODE = {
 }
 
 SEVERITY_MAPPING = {1: "High", 2: "High", 3: "Medium", 4: "Low", 5: "Low"}
-DTM_SEVERITY_MAPPING = {"high": "high", "medium": "medium", "low": "low"}
 
 # Map status of ASM issue to status of container
 ASM_STATUS_MAPPING = {

--- a/manual_readme_content.md
+++ b/manual_readme_content.md
@@ -83,6 +83,8 @@ ______________________________________________________________________
   | Medium | Medium |
   | Low | Low |
 
+  The connector matches these values to enabled Splunk SOAR severity names. If a stock name is not enabled, High maps to the highest-ranked enabled severity, Medium maps to the enabled default (or the middle-ranked severity if no default is identified), and Low maps to the lowest-ranked enabled severity. Missing and unrecognized DTM severity values map to the highest-ranked enabled severity.
+
 - **Container Creation:**\
   Each DTM alert will result in the creation of a separate container. One artifact will be created inside the container and will have certain important fields from alert visible inside the artifact. To get complete details about the alert, download the artifact JSON.
 

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,3 +1,4 @@
 **Unreleased**
 
 * Map DTM alert severities to enabled Splunk SOAR severities and fail up to the highest-ranked enabled severity for missing or unrecognized values.
+* Continue ingesting newer DTM alerts after an individual failure and retry missing artifacts in existing containers before advancing the checkpoint.

--- a/release_notes/unreleased.md
+++ b/release_notes/unreleased.md
@@ -1,1 +1,3 @@
 **Unreleased**
+
+* Map DTM alert severities to enabled Splunk SOAR severities and fail up to the highest-ranked enabled severity for missing or unrecognized values.


### PR DESCRIPTION
## Summary

- map DTM high, medium, and low values onto the deployment's enabled severity policy
- fail missing or unrecognized values up to the highest-ranked enabled severity
- retain the provider severity in artifact CEF and raw data
- continue newer DTM alert ingestion after an individual save failure
- retry missing artifacts in existing containers before advancing the checkpoint

## Tracking

- [PAPP-38192](https://splunk.atlassian.net/browse/PAPP-38192)
- [PSAAS-32199](https://splunk.atlassian.net/browse/PSAAS-32199)
- [VULN-94922](https://splunk.atlassian.net/browse/VULN-94922)
- Parent epic: [ESPM-5228](https://splunk.atlassian.net/browse/ESPM-5228)

## Quality gate

- Python source compilation and source-quality hooks: passed locally
- local package hook requires Docker; hosted workflow is authoritative
- hosted pre-commit: passed
- hosted compile: blocked before connector execution because shared current instance `10.1.19.193` is unreachable
- exact dual-review source validation: passed at head `030e5c9`

## Release impact

This is a patch release. Provider severity remains available in artifact evidence; the native platform severity now uses the deployment's enabled names and ranking. The two fixes are separate commits and separate release-note lines.

Merge strategy: merge commit only; do not squash.

Created with Codex AI assistance.
